### PR TITLE
Add package.json to allow for publishing to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "jasmine-favicon-reporter",
+  "version": "1.0.0",
+  "description": "Jasmine reporter that shows count of *RED* tests in favicon.",
+  "main": "jasmine-favicon-reporter.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/simsalabim/jasmine-favicon-reporter.git"
+  },
+  "keywords": [
+    "jasmine",
+    "reporter",
+    "favicon",
+    "bdd"
+  ],
+  "author": "Alexander Kaupanin <kaupanin@gmail.com>",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/simsalabim/jasmine-favicon-reporter/issues"
+  },
+  "homepage": "http://simsalabim.github.io/jasmine-favicon-reporter"
+}


### PR DESCRIPTION
Thanks for the awesome project! We've used this for many years.

We are converting many of our projects from bower to npm. This PR would allow this project to be published to npm. If you would accept it and then run [`npm publish`](https://docs.npmjs.com/cli/publish) we would greatly appreciate it!

I've checked for possible package naming conflicts in npm and found none so you should be good to go. Thanks!